### PR TITLE
.github/workflows: Add build checks.

### DIFF
--- a/.github/workflows/compile_examples.yml
+++ b/.github/workflows/compile_examples.yml
@@ -1,0 +1,19 @@
+name: Compile examples
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+      - main
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+  schedule:
+    - cron: '30 3 * * 5' # Run every Friday at 3:30 AM UTC
+
+jobs:
+  arduino-devops:
+    uses: Infineon/arduino-devops/.github/workflows/compile-examples-lib.yml@latest


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
This pull request introduces a new GitHub Actions workflow to compile example projects. The workflow is designed to run on various triggers, including pull requests, pushes to main branches, and a weekly schedule.

New GitHub Actions workflow:

* [`.github/workflows/compile_examples.yml`](diffhunk://#diff-2fe15684d86d735451a60f55aa318e9224d9c4091786f4c83a763641b8d64bc1R1-R19): Added a new workflow named "Compile examples" that triggers on `workflow_dispatch`, pushes to `master` or `main` branches, tags, pull requests, and a weekly cron schedule. The workflow uses the `arduino-devops` job from the Infineon repository to compile examples.